### PR TITLE
Use rate-limited endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,6 @@ debianPackageDependencies := Seq("openjdk-8-jre-headless")
 serverLoading in Debian := Some(ServerLoader.Systemd)
 serviceAutostart in Debian := false
 
-version in Debian := s"${version.value}-${sys.env.getOrElse("CIRCLE_BUILD_NUM","SNAPSHOT")}"
 name in Debian := "launchdetector"
 
 maintainer := "Andy Gallagher <andy.gallagher@theguardian.com>"

--- a/cloudformation/launchdetector.yaml
+++ b/cloudformation/launchdetector.yaml
@@ -71,6 +71,10 @@ Parameters:
   ElkStack:
     Description: Name of a deployed ELK6 stack (https://github.com/guardian/elk6) to send logs to
     Type: String
+  CapiApiKey:
+    Description: API key for Content API. Contact the Content API team to get or update this.
+    Type: String
+    NoEcho: true
 Resources:
   LoadBalancerSG:
     Type: AWS::EC2::SecurityGroup
@@ -245,7 +249,8 @@ Resources:
           #!/bin/bash -e
 
           mkdir -p /tmp/install
-          aws s3 sync s3://gnm-multimedia-rr-deployables/${Stack}/${Stage}/${App} /tmp/install
+
+          aws s3 cp s3://gnm-multimedia-rr-deployables/${Stack}/${Stage}/${App}/multimedia-launchdetector-v3_3.0_all.deb /tmp/install
           aws s3 cp s3://gnm-multimedia-rr-deployables/filebeat-6.1.2-amd64.deb /tmp/install
           aws s3 cp s3://gnm-multimedia-rr-deployables/metricbeat-6.1.2-amd64.deb /tmp/install
           dpkg -i /tmp/install/filebeat-6.1.2-amd64.deb
@@ -260,6 +265,7 @@ Resources:
           capi_stream_name = "${CapiStreamName}"
           capi_role_name = "${CapiRole}"
           capi_mode = "${Mode}"
+          capi_api_key = "${CapiApiKey}"
 
           app_name = "${App}"
           app_stack = "${Stack}"

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -28,7 +28,7 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
   protected val updater:ActorRef = context.actorOf(Props(new PlutoUpdaterActor(config)))
   protected val unattachedAtomActor:ActorRef = context.actorOf(Props(new UnattachedAtomActor(config)))
 
-  final val client: GuardianContentClient = new GuardianContentClient(config.getString("capi_api_key"))
+  protected def client: GuardianContentClient = new GuardianContentClient(config.getString("capi_api_key"))
 
   override def receive: Receive = {
     case LookupAtomId(atomId)=>

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -6,6 +6,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import akka.pattern.ask
+import com.gu.contentapi.client.GuardianContentClient
 import com.softwaremill.sttp.SttpBackend
 import com.softwaremill.sttp.akkahttp.AkkaHttpBackend
 import capi.CapiCommunicator
@@ -26,6 +27,8 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
 
   protected val updater:ActorRef = context.actorOf(Props(new PlutoUpdaterActor(config)))
   protected val unattachedAtomActor:ActorRef = context.actorOf(Props(new UnattachedAtomActor(config)))
+
+  final val client: GuardianContentClient = new GuardianContentClient(config.getString("capi_api_key"))
 
   override def receive: Receive = {
     case LookupAtomId(atomId)=>

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -28,7 +28,7 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
   protected val updater:ActorRef = context.actorOf(Props(new PlutoUpdaterActor(config)))
   protected val unattachedAtomActor:ActorRef = context.actorOf(Props(new UnattachedAtomActor(config)))
 
-  protected def client: GuardianContentClient = new GuardianContentClient(config.getString("capi_api_key"))
+  protected lazy val client: GuardianContentClient = new GuardianContentClient(config.getString("capi_api_key"))
 
   override def receive: Receive = {
     case LookupAtomId(atomId)=>

--- a/src/main/scala/capi/CapiCommunicator.scala
+++ b/src/main/scala/capi/CapiCommunicator.scala
@@ -2,9 +2,6 @@ package capi
 
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.GuardianContentClient
-import java.time.Instant
-
-import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentatom.thrift.Atom
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 
@@ -13,7 +10,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 trait CapiCommunicator {
-  def client: GuardianContentClient
+  protected def client: GuardianContentClient
 
   def lookupAtom(atomId:String, atomType:String):Future[Option[Atom]] = {
     val atomQuery = ItemQuery(s"atom/$atomType/$atomId")

--- a/src/main/scala/capi/CapiCommunicator.scala
+++ b/src/main/scala/capi/CapiCommunicator.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 trait CapiCommunicator {
-  protected def client: GuardianContentClient
+  protected val client: GuardianContentClient
 
   def lookupAtom(atomId:String, atomType:String):Future[Option[Atom]] = {
     val atomQuery = ItemQuery(s"atom/$atomType/$atomId")

--- a/src/main/scala/capi/CapiCommunicator.scala
+++ b/src/main/scala/capi/CapiCommunicator.scala
@@ -1,6 +1,7 @@
 package capi
 
 import com.gu.contentapi.client.model._
+import com.gu.contentapi.client.GuardianContentClient
 import java.time.Instant
 
 import com.gu.contentapi.client.model.v1.ItemResponse
@@ -12,7 +13,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 trait CapiCommunicator {
-  private val client = new GuardianContentClientInternal("multimedia-launchdetector")
+  def client: GuardianContentClient
 
   def lookupAtom(atomId:String, atomType:String):Future[Option[Atom]] = {
     val atomQuery = ItemQuery(s"atom/$atomType/$atomId")

--- a/src/main/scala/capi/GuardianContentClientInternal.scala
+++ b/src/main/scala/capi/GuardianContentClientInternal.scala
@@ -1,8 +1,0 @@
-package capi
-
-import com.gu.contentapi.client.GuardianContentClient
-
-/* override the client to hit the internal api endpoints, only possible from within GU networks */
-class GuardianContentClientInternal(apiKey:String) extends GuardianContentClient(apiKey:String) {
-  override val targetUrl: String = "https://internal.content.guardianapis.com"
-}

--- a/src/test/scala/TestForceUpdateActor.scala
+++ b/src/test/scala/TestForceUpdateActor.scala
@@ -55,7 +55,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
 
       val forceUpdateActor = system.actorOf(Props(new ForceUpdateActor(config){
         override protected val updater:ActorRef = fakeUpdater.ref
-        override protected def client:GuardianContentClient = null
+        override protected lazy val client:GuardianContentClient = null
 
         override def lookupAtom(atomId: String, atomType: String): Future[Option[Atom]] = Future(Some(testAtom))
       }), "ForceUpdater")
@@ -77,7 +77,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
 
     val forceUpdateActor = system.actorOf(Props(new ForceUpdateActor(config){
       override protected val updater:ActorRef = fakeUpdater.ref
-      override protected def client:GuardianContentClient = null
+      override protected lazy val client:GuardianContentClient = null
 
       override def lookupAtom(atomId: String, atomType: String): Future[Option[Atom]] = Future(None)
     }), "ForceUpdater")
@@ -96,7 +96,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
 
     val forceUpdateActor = system.actorOf(Props(new ForceUpdateActor(config){
       override protected val updater:ActorRef = fakeUpdater.ref
-      override protected def client:GuardianContentClient = null
+      override protected lazy val client:GuardianContentClient = null
 
       override def lookupAtom(atomId: String, atomType: String): Future[Option[Atom]] = Future(throw new Exception("something broke"))
     }), "ForceUpdater")

--- a/src/test/scala/TestForceUpdateActor.scala
+++ b/src/test/scala/TestForceUpdateActor.scala
@@ -2,17 +2,16 @@ import actors._
 import actors.messages._
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
-import akka.testkit.{ImplicitSender, TestActors, TestKit, TestProbe}
+import akka.testkit.{TestKit, TestProbe}
 import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
 import com.gu.contentatom.thrift.atom.media._
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.scalatest.{BeforeAndAfterAll, Matchers, OneInstancePerTest, WordSpecLike}
-import akka.http.scaladsl.model._
+import com.gu.contentapi.client.GuardianContentClient
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
 
 class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matchers with OneInstancePerTest {
   private implicit val system:ActorSystem = ActorSystem("TestPlutoUpdaterActor")
@@ -56,6 +55,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
 
       val forceUpdateActor = system.actorOf(Props(new ForceUpdateActor(config){
         override protected val updater:ActorRef = fakeUpdater.ref
+        override protected def client:GuardianContentClient = null
 
         override def lookupAtom(atomId: String, atomType: String): Future[Option[Atom]] = Future(Some(testAtom))
       }), "ForceUpdater")
@@ -77,6 +77,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
 
     val forceUpdateActor = system.actorOf(Props(new ForceUpdateActor(config){
       override protected val updater:ActorRef = fakeUpdater.ref
+      override protected def client:GuardianContentClient = null
 
       override def lookupAtom(atomId: String, atomType: String): Future[Option[Atom]] = Future(None)
     }), "ForceUpdater")
@@ -95,6 +96,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
 
     val forceUpdateActor = system.actorOf(Props(new ForceUpdateActor(config){
       override protected val updater:ActorRef = fakeUpdater.ref
+      override protected def client:GuardianContentClient = null
 
       override def lookupAtom(atomId: String, atomType: String): Future[Option[Atom]] = Future(throw new Exception("something broke"))
     }), "ForceUpdater")


### PR DESCRIPTION
Have created a key, will send to the relevant people who must add a `capi_api_key` configuration entry with it.