### PR TITLE
Fix for incorrect case bug, https://codemill.atlassian.net/browse/GP-335

### DIFF
--- a/src/main/scala/HttpServer.scala
+++ b/src/main/scala/HttpServer.scala
@@ -35,7 +35,7 @@ class HttpServer(forceActorUpdater: ActorRef) {
             onSuccess((forceActorUpdater ? LookupAtomId(docId)).mapTo[Either[ActorMessage,SuccessfulSend]]) {
               case Left(error: ActorMessage)=>
                 complete(HttpEntity(ContentTypes.`application/json`, s"""{"status":"error","atomid":"$docId","detail":"Unable to process: ${error.getMessage}"}"""))
-              case Right(message: SuccessfulSend)=>
+              case Right(_: SuccessfulSend)=>
                 complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, s"""{"status":"ok","atomid":"$docId"}"""))
             }
         }

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -46,14 +46,11 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
                   logger.info(s"Got atom with title ${atom.title}")
 
                   (updater ? DoUpdate(atom)).onComplete({
-                    case Success(result:Either[ErrorSend,SuccessfulSend])=>
-
-                      result.fold({error=>
-                        originalSender ! Left(error)
-                      }, {result=>
-                        unattachedAtomActor ! MasterNowAttached(atom.id)
-                        originalSender ! Right(result)
-                      })
+                    case Success(result:SuccessfulSend)=>
+                      unattachedAtomActor ! MasterNowAttached(atom.id)
+                      originalSender ! Right(result)
+                    case Success(result:ErrorSend)=>
+                        originalSender ! Left(result)
                     case Failure(error)=>originalSender ! Left(error)
                   })
             case None =>

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -61,7 +61,7 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
           logger.error(s"Atom $atomId could not be loaded: $error")
           originalSender ! Left(ErrorSend(s"Atom $atomId could not be loaded: $error", -1))
       })
-    case _=>
-      logger.warning("ForceUpdateActor received an unexpected message")
+    case msg:_=>
+      logger.warning(s"ForceUpdateActor received an unexpected message: ${msg.getClass.getTypeName} ${msg.getClass.getName} ${msg.getClass.getCanonicalName}")
   }
 }

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -42,17 +42,17 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
         case Success(maybeAtom)=>
           maybeAtom match {
             case Some(atom) =>
-                  logger.info(s"orignal sender is $originalSender")
-                  logger.info(s"Got atom with title ${atom.title}")
+              logger.info(s"orignal sender is $originalSender")
+              logger.info(s"Got atom with title ${atom.title}")
 
-                  (updater ? DoUpdate(atom)).onComplete({
-                    case Success(result:SuccessfulSend)=>
-                      unattachedAtomActor ! MasterNowAttached(atom.id)
-                      originalSender ! Right(result)
-                    case Success(result:ErrorSend)=>
-                        originalSender ! Left(result)
-                    case Failure(error)=>originalSender ! Left(error)
-                  })
+              (updater ? DoUpdate(atom)).onComplete({
+                case Success(result:SuccessfulSend)=>
+                  unattachedAtomActor ! MasterNowAttached(atom.id)
+                  originalSender ! Right(result)
+                case Success(result:ErrorSend)=>
+                    originalSender ! Left(result)
+                case Failure(error)=>originalSender ! Left(error)
+              })
             case None =>
               logger.error(s"Atom $atomId is valid but not a media atom")
               originalSender ! Left(ErrorSend(s"Atom $atomId is valid but not a media atom", -1))
@@ -61,6 +61,8 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
           logger.error(s"Atom $atomId could not be loaded: $error")
           originalSender ! Left(ErrorSend(s"Atom $atomId could not be loaded: $error", -1))
       })
+    case SuccessfulSend()=>
+      //just ignore this, it comes through as a side-effect to the DoUpdate completing but it's properly handled in the ask block above
     case msg:Any=>
       logger.warning(s"ForceUpdateActor received an unexpected message: ${msg.getClass.getTypeName} ${msg.getClass.getName} ${msg.getClass.getCanonicalName}")
   }

--- a/src/main/scala/actors/ForceUpdateActor.scala
+++ b/src/main/scala/actors/ForceUpdateActor.scala
@@ -61,7 +61,7 @@ class ForceUpdateActor(config:Config) extends Actor with CapiCommunicator {
           logger.error(s"Atom $atomId could not be loaded: $error")
           originalSender ! Left(ErrorSend(s"Atom $atomId could not be loaded: $error", -1))
       })
-    case msg:_=>
+    case msg:Any=>
       logger.warning(s"ForceUpdateActor received an unexpected message: ${msg.getClass.getTypeName} ${msg.getClass.getName} ${msg.getClass.getCanonicalName}")
   }
 }

--- a/src/test/scala/TestForceUpdateActor.scala
+++ b/src/test/scala/TestForceUpdateActor.scala
@@ -63,7 +63,7 @@ class TestForceUpdateActor extends WordSpecLike with BeforeAndAfterAll with Matc
       val resultFuture = forceUpdateActor.ask(LookupAtomId("some-atom-id"))
 
       fakeUpdater.expectMsg(10.seconds, DoUpdate(testAtom))
-      fakeUpdater.reply(Right(SuccessfulSend()))
+      fakeUpdater.reply(SuccessfulSend())
 
       val result = Await.result(resultFuture, 15.seconds)
       result should be(Right(SuccessfulSend()))


### PR DESCRIPTION
## What does this change?
Fix for missing-case bug detailed at https://codemill.atlassian.net/browse/GP-335.  Fixes the return type from PlutoUpdaterActor when receiving messages in ForceUpdateActor

## How to test
Make a RESYNC request from pluto to a valid atom ID, the request should succeed instead of failing on a 500 error

## How can we measure success?
Resync functionality (https://codemill.atlassian.net/browse/GP-235?atlOrigin=eyJpIjoiMWUzNDk4ZTQ2NjllNDljYWI4ZTVkMmI5M2FiNDVkODEiLCJwIjoiaiJ9) should work


