### PR TITLE
Youtube metadata output

### DIFF
--- a/src/main/resources/logback-deployment.xml
+++ b/src/main/resources/logback-deployment.xml
@@ -26,6 +26,7 @@
     <logger name="ShutdownHandler" level="INFO"/>
     <logger name="LaunchdetectorStreamListener" level="INFO"/>
     <logger name="PlutoNextGen" level="INFO"/>
+    <logger name="PlutoNextGen.UpdateJsonGenerator" level="DEBUG"/>
 
     <!-- library loggers -->
     <logger name="akka.event.EventStream" level="INFO"/>

--- a/src/main/resources/logback-deployment.xml
+++ b/src/main/resources/logback-deployment.xml
@@ -24,7 +24,8 @@
     <logger name="MainClass$" level="INFO"/>
     <logger name="Healthcheck$" level="INFO"/>
     <logger name="ShutdownHandler" level="INFO"/>
-    <logger name="actors.PlutoUpdaterActor" level="INFO"/>
+    <logger name="LaunchdetectorStreamListener" level="INFO"/>
+    <logger name="PlutoNextGen" level="INFO"/>
 
     <!-- library loggers -->
     <logger name="akka.event.EventStream" level="INFO"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,6 +21,7 @@
     <logger name="actors.PlutoUpdaterActor" level="INFO"/>
     <logger name="LaunchdetectorStreamListener" level="INFO"/>
     <logger name="PlutoNextGen" level="INFO"/>
+    <logger name="PlutoNextGen.UpdateJsonGenerator" level="DEBUG"/>
 
     <!-- library loggers -->
     <logger name="akka.event.EventStream" level="INFO"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -19,7 +19,8 @@
     <logger name="Healthcheck$" level="INFO"/>
     <logger name="ShutdownHandler" level="INFO"/>
     <logger name="actors.PlutoUpdaterActor" level="INFO"/>
-    <logger name="PlutoNextGen" level="DEBUG"/>
+    <logger name="LaunchdetectorStreamListener" level="INFO"/>
+    <logger name="PlutoNextGen" level="INFO"/>
 
     <!-- library loggers -->
     <logger name="akka.event.EventStream" level="INFO"/>

--- a/src/main/scala/LaunchdetectorStreamListener.scala
+++ b/src/main/scala/LaunchdetectorStreamListener.scala
@@ -87,7 +87,9 @@ class LaunchdetectorStreamListener(updater:ActorRef) extends StreamListener {
     val filepath = Seq(homedir, atom.id).mkString("/")
 
     atom.atomType match {
-      case AtomType.Media=>updater ! DoUpdate(atom)
+      case AtomType.Media=>
+        logger.info(atomUpdateInfo(atom))
+        updater ! DoUpdate(atom)
       case _=>  //just ignore anything else
     }
 

--- a/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
+++ b/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
@@ -29,6 +29,8 @@ object UpdateJsonGenerator {
       md.tags,
       md.privacyStatus.map(_.toString),
       md.license,
+      md.youtube.map(_.title),
+      md.youtube.flatMap(_.description)
     ))
 
     val msg = UpdateMessage (

--- a/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
+++ b/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
@@ -23,7 +23,7 @@ object UpdateJsonGenerator {
     ))
 
     val ytMeta = mediaContent.metadata.map(md=>YTMeta(
-      md.channelId,
+      md.categoryId,
       md.channelId,
       md.expiryDate.map(asIsoTimeString),
       md.tags,

--- a/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
+++ b/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
@@ -14,9 +14,21 @@ object UpdateJsonGenerator {
     val mediaContent = atom.data.asInstanceOf[AtomData.Media].media
     val contentChangeDetails = atom.contentChangeDetails
 
-    mediaContent.assets.foreach(asset=>{
-      logger.info(s"${atom.id}: Got media asset from platform ${asset.platform} of type ${asset.assetType} with version ${asset.version} and id ${asset.id} with mime type ${asset.mimeType}")
-    })
+    val mappedAssets = mediaContent.assets.map(a=>AssetRef(
+      a.mimeType,
+      a.assetType.toString,
+      a.platform.toString,
+      a.id
+    ))
+
+    val ytMeta = mediaContent.metadata.map(md=>YTMeta(
+      md.channelId,
+      md.channelId,
+      md.expiryDate.map(asIsoTimeString),
+      md.tags,
+      md.privacyStatus.map(_.toString),
+      md.license,
+    ))
 
     val msg = UpdateMessage (
       title = mediaContent.title,
@@ -48,7 +60,9 @@ object UpdateJsonGenerator {
       projectId = mediaContent.metadata.flatMap(_.pluto).flatMap(_.projectId),
       masterId = mediaContent.metadata.flatMap(_.pluto).flatMap(_.masterId),
       published = contentChangeDetails.published.map(InlineChangeRecord.fromChangeRecord),
-      lastModified = contentChangeDetails.lastModified.map(InlineChangeRecord.fromChangeRecord)
+      lastModified = contentChangeDetails.lastModified.map(InlineChangeRecord.fromChangeRecord),
+      assets = mappedAssets,
+      ytMeta = ytMeta
     )
 
     msg.asJson

--- a/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
+++ b/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
@@ -1,17 +1,22 @@
 package PlutoNextGen
 
 import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
-
 import io.circe.generic.auto._
 import io.circe.syntax._
 import com.gu.contentatom.thrift.{Atom, AtomData}
+import org.slf4j.LoggerFactory
 
 object UpdateJsonGenerator {
+  private val logger = LoggerFactory.getLogger(getClass)
   def asIsoTimeString(epochTime:Long):String = ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochTime),ZoneOffset.UTC).toString
 
   def makeContentJson(atom:Atom, currentTime: LocalDateTime) = {
     val mediaContent = atom.data.asInstanceOf[AtomData.Media].media
     val contentChangeDetails = atom.contentChangeDetails
+
+    mediaContent.assets.foreach(asset=>{
+      logger.info(s"${atom.id}: Got media asset from platform ${asset.platform} of type ${asset.assetType} with version ${asset.version} and id ${asset.id} with mime type ${asset.mimeType}")
+    })
 
     val msg = UpdateMessage (
       title = mediaContent.title,

--- a/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
+++ b/src/main/scala/PlutoNextGen/UpdateJsonGenerator.scala
@@ -18,7 +18,8 @@ object UpdateJsonGenerator {
       a.mimeType,
       a.assetType.toString,
       a.platform.toString,
-      a.id
+      a.id,
+      a.version
     ))
 
     val ytMeta = mediaContent.metadata.map(md=>YTMeta(

--- a/src/main/scala/PlutoNextGen/UpdateMessage.scala
+++ b/src/main/scala/PlutoNextGen/UpdateMessage.scala
@@ -45,7 +45,9 @@ case class YTMeta(
                  expiryDate: Option[String],
                  keywords: Option[Seq[String]],
                  privacyStatus: Option[String],
-                 license: Option[String]
+                 license: Option[String],
+                 title: Option[String],
+                 description: Option[String]
                  )
 
 case class UpdateMessage(

--- a/src/main/scala/PlutoNextGen/UpdateMessage.scala
+++ b/src/main/scala/PlutoNextGen/UpdateMessage.scala
@@ -30,6 +30,23 @@ object InlineChangeRecord {
     )
   }
 }
+
+case class AssetRef(
+                   maybeMimeType: Option[String],
+                   assetType: String,
+                   platform: String,
+                   platformId: String
+                   )
+
+case class YTMeta(
+                 categoryId: Option[String],
+                 channelId: Option[String],
+                 expiryDate: Option[String],
+                 keywords: Option[Seq[String]],
+                 privacyStatus: Option[String],
+                 license: Option[String]
+                 )
+
 case class UpdateMessage(
                         title: String,
                         category: String,
@@ -46,5 +63,7 @@ case class UpdateMessage(
                         projectId: Option[String],
                         masterId: Option[String],
                         published: Option[InlineChangeRecord],
-                        lastModified: Option[InlineChangeRecord]
-                        )
+                        lastModified: Option[InlineChangeRecord],
+                        assets: Seq[AssetRef],
+                        ytMeta: Option[YTMeta]
+)

--- a/src/main/scala/PlutoNextGen/UpdateMessage.scala
+++ b/src/main/scala/PlutoNextGen/UpdateMessage.scala
@@ -35,7 +35,8 @@ case class AssetRef(
                    maybeMimeType: Option[String],
                    assetType: String,
                    platform: String,
-                   platformId: String
+                   platformId: String,
+                   version: Long,
                    )
 
 case class YTMeta(

--- a/src/main/scala/actors/PlutoUpdaterActor.scala
+++ b/src/main/scala/actors/PlutoUpdaterActor.scala
@@ -38,12 +38,14 @@ class PlutoUpdaterActor(config:Config) extends Actor with DeliverablesCommunicat
     case DoUpdate(atom)=>
       logger.info(s"Received update request from ${sender()}")
       val origSender = sender() //need to make a copy of this so when it's called from another thread in map() below it is passed correctly.
+      logger.info(atom.toString())
+
       doUpdate(atom).onComplete({
         case Success(serverResponse)=>
           logger.info(s"Successfully updated pluto-deliverables: $serverResponse")
           origSender ! SuccessfulSend()
         case Failure(error)=>
-          logger.error(s"Unable to update vidispine: $error")
+          logger.error(s"Unable to update pluto-deliverables: $error")
           origSender ! ErrorSend(error.getMessage, -1)
       })
     case _=>logger.error(s"Received an unknown message")


### PR DESCRIPTION
## What does this change?
Adds youtube information into launch detector output fields

## How to test
Deploy to CODE
Deploy the corresponding PR https://gitlab.com/codmill/customer-projects/guardian/pluto-deliverables/-/merge_requests/79 to  pluto-deliverables CODE in order to receive the data.
Create and publish and atom in CODE.
The corresponding deliverable in pluto-deliverables CODE should have the associated youtube tags, id etc. associated with it

## How can we measure success?
Getting published YT information trhough, in order to speed up syndication tasks.

## Have we considered potential risks?
Syndication staff will be kept in the loop

