### PR TITLE
Feature/auto update ami

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,9 +9,11 @@ deployments:
       bucket: gnm-multimedia-rr-deployables
       healthcheckGrace: 25
       secondsToWait: 300
+    dependencies: [ multimedia-ami-update ]
   multimedia-ami-update:
     type: ami-cloudformation-parameter
-    amiParameter: AmiId
-    amiTags:
-      BuiltBy: amigo
-      Recipe: multimedia-tools-focal-java11
+    parameters:
+      amiParameter: AmiId
+      amiTags:
+        BuiltBy: amigo
+        Recipe: multimedia-tools-focal-java11

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,3 +9,9 @@ deployments:
       bucket: gnm-multimedia-rr-deployables
       healthcheckGrace: 25
       secondsToWait: 300
+  multimedia-ami-update:
+    type: ami-cloudformation-parameter
+    amiParameter: AmiId
+    amiTags:
+      BuiltBy: amigo
+      Recipe: multimedia-tools-focal-java11

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,6 +12,7 @@ deployments:
     dependencies: [ multimedia-ami-update ]
   multimedia-ami-update:
     type: ami-cloudformation-parameter
+    app: launchdetector
     parameters:
       amiParameter: AmiId
       amiTags:


### PR DESCRIPTION
## What does this change?
Updates the Riffraff deployment to automatically bump to the latest AMI image at every deploy

## How to test

Deploy this branch out via riffraff. You should see an extra entry saying `task UpdateAmiCloudFormationParameterTask Update AmiId to latest AMI with tags Map(BuiltBy -> amigo, Recipe -> multimedia-tools-focal-java11) ....` as per the screenshot below.

When you cross-reference the current AMI ID against Amigo you should see that it has been changed to the latest.
 
## How can we measure success?

Always have an up to date AMI

## Have we considered potential risks?

n/a

## Images

![Screenshot 2022-02-22 at 12 26 45](https://user-images.githubusercontent.com/12482441/155132305-f53ef40f-83ed-4b8c-8b0e-8460ecd8724e.png)

